### PR TITLE
Update droplet to avoid deprecated initializer

### DIFF
--- a/Sources/App/main.swift
+++ b/Sources/App/main.swift
@@ -8,10 +8,11 @@ import TurnstileWeb
 import Fluent
 import Foundation
 
-let auth = AuthMiddleware<DemoUser>()
-let database = Database(MemoryDriver())
-
-let drop = Droplet(database: database, availableMiddleware: ["auth": auth, "trustProxy": TrustProxyMiddleware()], preparations: [DemoUser.self])
+let drop = Droplet()
+drop.database = Database(MemoryDriver())
+drop.middleware.append(AuthMiddleware(user: DemoUser.self))
+drop.middleware.append(TrustProxyMiddleware())
+drop.preparations.append(DemoUser.self)
 
 /**
  Endpoint for the home page.


### PR DESCRIPTION
Vapor now encourages `Droplets` to be created using an empty initializer. Middleware and preparations should be supplied after a `Droplet` has been created.